### PR TITLE
UP2-564 hotfix for Case ownership race condition

### DIFF
--- a/classes/trac_CaseTriggerHelper.cls
+++ b/classes/trac_CaseTriggerHelper.cls
@@ -991,10 +991,13 @@ public without sharing class trac_CaseTriggerHelper {
 
         if (mapToUpdate!=null && !mapToUpdate.isEmpty()) {
             upsert mapToUpdate.values();
+            List<Case> updateCases = new List<Case>();
             for (Case aCase : cases) {
-                aCase.ContactId = mapToUpdate.get(aCase.Id).Id;
+                // update a fresh instance of Case with limited properties, because the one from the JSON is stale
+                //   (i.e. OwnerId has changed due to case assignment rules)
+                updateCases.add(new Case(Id=aCase.Id, ContactId=mapToUpdate.get(aCase.Id).Id));
             }
-            update cases;
+            update updateCases;
         }
 
 

--- a/classes/trac_CaseTriggerHelperTest.cls
+++ b/classes/trac_CaseTriggerHelperTest.cls
@@ -186,6 +186,8 @@ private class trac_CaseTriggerHelperTest {
         Test.startTest();
         insert aCase;
         Test.stopTest();
-        
+
+        aCase = [SELECT Id, ContactId FROM Case WHERE Id =: aCase.Id];
+        System.assertNotEquals(null, aCase.ContactId);
     }
 }


### PR DESCRIPTION
* new logic to update fresh instance of case rather than the stale one from the JSON
* prevents overwriting unintended properties like OwnerId
* added assertion to test class